### PR TITLE
Remove gitignore rule that does not work as expected/documented

### DIFF
--- a/src/main/resources/jmetemplate/[DOT]gitignore
+++ b/src/main/resources/jmetemplate/[DOT]gitignore
@@ -6,8 +6,6 @@
 /*.dylib
 /*.so
 
-#Although most of the .idea directory should not be committed there is a legitimate purpose for committing run configurations
 /.idea/
-!/.idea/runConfigurations/
 
 local.properties


### PR DESCRIPTION
I used the initializer yesterday to create my first test project.

Looking through the generated code I noticed a rule in the .gitignore that does not work as one would expect (which was very nicely, yet incorrectly, documented in a comment).


From: https://www.atlassian.com/git/tutorials/saving-changes/gitignore

These rules

    logs/
    !logs/important.log

ignore these files

    logs/debug.log
    logs/important.log

Documentation:

    Wait a minute! Shouldn't logs/important.log be negated in the example on the left
    Nope! Due to a performance-related quirk in Git, you can not negate a file that
    is ignored due to a pattern matching a directory

I double checked with git and this documentation is actually right.